### PR TITLE
Python 3 compatibility for MethodView

### DIFF
--- a/flask_jsontools/views.py
+++ b/flask_jsontools/views.py
@@ -3,6 +3,10 @@ from collections import defaultdict
 from flask.views import View, with_metaclass
 from flask import request
 from werkzeug.exceptions import MethodNotAllowed
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 def methodview(methods=(), ifnset=None, ifset=None):


### PR DESCRIPTION
Py3k update

This should still support Python 2.x, but in Python 3.x basestring is gone (replaced by just str).  This resolves the `NameError` exception raised when using `MethodView` in Python 3.
