### PR TITLE
Using flask.json for formatting to allow using another json library

### DIFF
--- a/flask_jsontools/formatting.py
+++ b/flask_jsontools/formatting.py
@@ -1,4 +1,4 @@
-from json import JSONEncoder
+from flask.json import JSONEncoder
 
 
 class DynamicJSONEncoder(JSONEncoder):


### PR DESCRIPTION
Currently, if you are using `simplejson` (which can be used inside flask), you are not able to instantiate a json encoder correctly.
